### PR TITLE
Fix java-doc build error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,10 @@ java {
 	withSourcesJar()
 }
 
+javadoc {
+    options.encoding = 'UTF-8'
+}
+
 test {
 	useJUnitPlatform()
 


### PR DESCRIPTION
Fixes the error that occurs during the build process due to incorrect encoding.

```
 \src\de\cuuky\varo\entity\player\event\events\WinEvent.java:37: error: unmappable character (0x8F) for encoding windows-1252
			wins = Integer.valueOf(name.split("\\|")[1].replace("ð�?", "").replace(" ", ""));
```
```
\src\de\cuuky\varo\entity\player\event\events\WinEvent.java:42: error: unmappable character (0x8F) for encoding windows-1252
			member.modifyNickname(member.getUser().getName() + " | " + wins + " ð�?");
```