### PR TITLE
AutoSetup: add Y-position snapping capability for lobby spawnpoint

### DIFF
--- a/src/de/cuuky/varo/configuration/configurations/config/ConfigSetting.java
+++ b/src/de/cuuky/varo/configuration/configurations/config/ConfigSetting.java
@@ -21,8 +21,10 @@ public enum ConfigSetting implements SectionEntry {
 	// AUTOSETUP
 	AUTOSETUP_ENABLED(ConfigSettingSection.AUTOSETUP, "enabled", false, "Wenn Autosetup aktiviert ist, werden beim\nStart des Servers alle Spawns automatisch gesetzt und\noptional ein Autostart eingerichtet."),
 	AUTOSETUP_LOBBY_ENABLED(ConfigSettingSection.AUTOSETUP, "lobby.enabled", true, "Ob eine Lobby beim AutoSetup gespawnt werden soll"),
-	AUTOSETUP_LOBBY_SNAP(ConfigSettingSection.AUTOSETUP, "lobby.snap", AutoSetup.LobbySnap.MAX_HEIGHT.name(), "Naeherungsweise von welcher Position auf der Y-Achse\ndie Lobby gespawnt werden soll\n\nMoegliche Werte: GROUND, MAX_HEIGHT, ABSOLUTE"),
-	AUTOSETUP_LOBBY_SNAP_OFFSET(ConfigSettingSection.AUTOSETUP, "lobby.snapOffset", 50, "Wie weit von ihrem Snap-Punkt entfernt\ndie Lobby gespawnt werden soll"),
+	AUTOSETUP_LOBBY_SNAP_TYPE(ConfigSettingSection.AUTOSETUP, "lobby.snap.type", AutoSetup.LobbySnap.MAX_HEIGHT.name(), "Naeherungsweise von welcher Position auf der Y-Achse\ndie Lobby gespawnt werden soll\n\nMoegliche Werte: GROUND, MAX_HEIGHT, ABSOLUTE"),
+	AUTOSETUP_LOBBY_SNAP_GROUND_OFFSET(ConfigSettingSection.AUTOSETUP, "lobby.snap.ground.offset", 0, "Wie weit über dem Boden\ndie Lobby gespawnt werden soll.\n\nWird genutzt, wenn lobby.snap.type = GROUND"),
+	AUTOSETUP_LOBBY_SNAP_MAX_HEIGHT_OFFSET(ConfigSettingSection.AUTOSETUP, "lobby.snap.maxHeight.offset", 50, "Wie weit unter der maximalen Höhe\ndie Lobby gespawnt werden soll.\n\nWird genutzt, wenn lobby.snap.type = MAX_HEIGHT"),
+	AUTOSETUP_LOBBY_SNAP_ABSOLUTE_YPOS(ConfigSettingSection.AUTOSETUP, "lobby.snap.absolute.ypos", 64, "Auf welcher Y-Koordinate\ndie Lobby gespawnt werden soll.\n\nWird genutzt, wenn lobby.snap.type = ABSOLUTE"),
 	AUTOSETUP_LOBBY_SCHEMATIC(ConfigSettingSection.AUTOSETUP, "lobby.schematic", "plugins/Varo/schematics/lobby.schematic", "Schreibe hier den Pfad deiner Lobby-Schematic\nhin, die gepastet werden soll.\nHinweis: WorldEdit benoetigt"),
 	AUTOSETUP_LOBBY_GEN_HEIGHT(ConfigSettingSection.AUTOSETUP, "lobby.gen.height", 10, "Wand-Hoehe der Lobby, die generiert werden soll"),
 	AUTOSETUP_LOBBY_GEN_SIZE(ConfigSettingSection.AUTOSETUP, "lobby.gen.size", 25, "Groesse der Lobby, die generiert werden soll"),

--- a/src/de/cuuky/varo/configuration/configurations/config/ConfigSetting.java
+++ b/src/de/cuuky/varo/configuration/configurations/config/ConfigSetting.java
@@ -1,5 +1,6 @@
 package de.cuuky.varo.configuration.configurations.config;
 
+import de.cuuky.varo.game.world.setup.AutoSetup;
 import org.bukkit.Bukkit;
 
 import de.cuuky.cfw.version.BukkitVersion;
@@ -20,8 +21,10 @@ public enum ConfigSetting implements SectionEntry {
 	// AUTOSETUP
 	AUTOSETUP_ENABLED(ConfigSettingSection.AUTOSETUP, "enabled", false, "Wenn Autosetup aktiviert ist, werden beim\nStart des Servers alle Spawns automatisch gesetzt und\noptional ein Autostart eingerichtet."),
 	AUTOSETUP_LOBBY_ENABLED(ConfigSettingSection.AUTOSETUP, "lobby.enabled", true, "Ob eine Lobby beim AutoSetup gespawnt werden soll"),
-	AUTOSETUP_LOBBY_HEIGHT(ConfigSettingSection.AUTOSETUP, "lobby.height", 10, "Hoehe der Lobby, die gespawnt werden soll"),
+	AUTOSETUP_LOBBY_SNAP(ConfigSettingSection.AUTOSETUP, "lobby.snap", AutoSetup.LobbySnap.MAX_HEIGHT.name(), "Naeherungsweise von welcher Position auf der Y-Achse\ndie Lobby gespawnt werden soll\n\nMoegliche Werte: GROUND, MAX_HEIGHT, ABSOLUTE"),
+	AUTOSETUP_LOBBY_SNAP_OFFSET(ConfigSettingSection.AUTOSETUP, "lobby.snapOffset", 50, "Wie weit von ihrem Snap-Punkt entfernt\ndie Lobby gespawnt werden soll"),
 	AUTOSETUP_LOBBY_SCHEMATIC(ConfigSettingSection.AUTOSETUP, "lobby.schematic", "plugins/Varo/schematics/lobby.schematic", "Schreibe hier den Pfad deiner Lobby-Schematic\nhin, die gepastet werden soll.\nHinweis: WorldEdit benoetigt"),
+	AUTOSETUP_LOBBY_HEIGHT(ConfigSettingSection.AUTOSETUP, "lobby.height", 10, "Wand-Hoehe der Lobby, die gespawnt werden soll"),
 	AUTOSETUP_LOBBY_SIZE(ConfigSettingSection.AUTOSETUP, "lobby.size", 25, "Groesse der Lobby, die gespawnt werden soll"),
 
 	AUTOSETUP_PORTAL_ENABLED(ConfigSettingSection.AUTOSETUP, "portal.enabled", true, "Ob ein Portal gespawnt werden soll"),

--- a/src/de/cuuky/varo/configuration/configurations/config/ConfigSetting.java
+++ b/src/de/cuuky/varo/configuration/configurations/config/ConfigSetting.java
@@ -24,8 +24,8 @@ public enum ConfigSetting implements SectionEntry {
 	AUTOSETUP_LOBBY_SNAP(ConfigSettingSection.AUTOSETUP, "lobby.snap", AutoSetup.LobbySnap.MAX_HEIGHT.name(), "Naeherungsweise von welcher Position auf der Y-Achse\ndie Lobby gespawnt werden soll\n\nMoegliche Werte: GROUND, MAX_HEIGHT, ABSOLUTE"),
 	AUTOSETUP_LOBBY_SNAP_OFFSET(ConfigSettingSection.AUTOSETUP, "lobby.snapOffset", 50, "Wie weit von ihrem Snap-Punkt entfernt\ndie Lobby gespawnt werden soll"),
 	AUTOSETUP_LOBBY_SCHEMATIC(ConfigSettingSection.AUTOSETUP, "lobby.schematic", "plugins/Varo/schematics/lobby.schematic", "Schreibe hier den Pfad deiner Lobby-Schematic\nhin, die gepastet werden soll.\nHinweis: WorldEdit benoetigt"),
-	AUTOSETUP_LOBBY_HEIGHT(ConfigSettingSection.AUTOSETUP, "lobby.height", 10, "Wand-Hoehe der Lobby, die gespawnt werden soll"),
-	AUTOSETUP_LOBBY_SIZE(ConfigSettingSection.AUTOSETUP, "lobby.size", 25, "Groesse der Lobby, die gespawnt werden soll"),
+	AUTOSETUP_LOBBY_GEN_HEIGHT(ConfigSettingSection.AUTOSETUP, "lobby.gen.height", 10, "Wand-Hoehe der Lobby, die generiert werden soll"),
+	AUTOSETUP_LOBBY_GEN_SIZE(ConfigSettingSection.AUTOSETUP, "lobby.gen.size", 25, "Groesse der Lobby, die generiert werden soll"),
 
 	AUTOSETUP_PORTAL_ENABLED(ConfigSettingSection.AUTOSETUP, "portal.enabled", true, "Ob ein Portal gespawnt werden soll"),
 	AUTOSETUP_PORTAL_HEIGHT(ConfigSettingSection.AUTOSETUP, "portal.height", 5, "Hoehe des gespawnten Portals"),

--- a/src/de/cuuky/varo/configuration/configurations/config/ConfigSetting.java
+++ b/src/de/cuuky/varo/configuration/configurations/config/ConfigSetting.java
@@ -25,9 +25,10 @@ public enum ConfigSetting implements SectionEntry {
 	AUTOSETUP_LOBBY_SNAP_GROUND_OFFSET(ConfigSettingSection.AUTOSETUP, "lobby.snap.ground.offset", 0, "Wie weit über dem Boden\ndie Lobby gespawnt werden soll.\n\nWird genutzt, wenn lobby.snap.type = GROUND"),
 	AUTOSETUP_LOBBY_SNAP_MAX_HEIGHT_OFFSET(ConfigSettingSection.AUTOSETUP, "lobby.snap.maxHeight.offset", 50, "Wie weit unter der maximalen Höhe\ndie Lobby gespawnt werden soll.\n\nWird genutzt, wenn lobby.snap.type = MAX_HEIGHT"),
 	AUTOSETUP_LOBBY_SNAP_ABSOLUTE_YPOS(ConfigSettingSection.AUTOSETUP, "lobby.snap.absolute.ypos", 64, "Auf welcher Y-Koordinate\ndie Lobby gespawnt werden soll.\n\nWird genutzt, wenn lobby.snap.type = ABSOLUTE"),
-	AUTOSETUP_LOBBY_SCHEMATIC(ConfigSettingSection.AUTOSETUP, "lobby.schematic", "plugins/Varo/schematics/lobby.schematic", "Schreibe hier den Pfad deiner Lobby-Schematic\nhin, die gepastet werden soll.\nHinweis: WorldEdit benoetigt"),
-	AUTOSETUP_LOBBY_GEN_HEIGHT(ConfigSettingSection.AUTOSETUP, "lobby.gen.height", 10, "Wand-Hoehe der Lobby, die generiert werden soll"),
-	AUTOSETUP_LOBBY_GEN_SIZE(ConfigSettingSection.AUTOSETUP, "lobby.gen.size", 25, "Groesse der Lobby, die generiert werden soll"),
+	AUTOSETUP_LOBBY_SCHEMATIC_ENABLED(ConfigSettingSection.AUTOSETUP, "lobby.schematic.enabled", false, "Wenn diese Option aktiviert ist, wird die Lobby\nanhand der angegeben Schematic gespawnt.\nAndernfalls wird die Lobby generiert.\n\nHinweis: WorldEdit benoetigt"),
+	AUTOSETUP_LOBBY_SCHEMATIC_FILE(ConfigSettingSection.AUTOSETUP, "lobby.schematic.file", "plugins/Varo/schematics/lobby.schematic", "Schreibe hier den Pfad deiner Lobby-Schematic\nhin, die gepastet werden soll."),
+	AUTOSETUP_LOBBY_GENERATED_HEIGHT(ConfigSettingSection.AUTOSETUP, "lobby.generated.height", 10, "Wand-Hoehe der Lobby, die generiert werden soll"),
+	AUTOSETUP_LOBBY_GENERATED_SIZE(ConfigSettingSection.AUTOSETUP, "lobby.generated.width", 25, "Breite der Lobby, die generiert werden soll"),
 
 	AUTOSETUP_PORTAL_ENABLED(ConfigSettingSection.AUTOSETUP, "portal.enabled", true, "Ob ein Portal gespawnt werden soll"),
 	AUTOSETUP_PORTAL_HEIGHT(ConfigSettingSection.AUTOSETUP, "portal.height", 5, "Hoehe des gespawnten Portals"),

--- a/src/de/cuuky/varo/game/world/setup/AutoSetup.java
+++ b/src/de/cuuky/varo/game/world/setup/AutoSetup.java
@@ -99,9 +99,11 @@ public class AutoSetup {
             }
 
             File schematicFile = new File(ConfigSetting.AUTOSETUP_LOBBY_SCHEMATIC_FILE.getValueAsString());
-            if (ConfigSetting.AUTOSETUP_LOBBY_SCHEMATIC_ENABLED.getValueAsBoolean() && schematicFile.exists()) {
+            boolean schematicEnabled = ConfigSetting.AUTOSETUP_LOBBY_SCHEMATIC_ENABLED.getValueAsBoolean();
+            if (schematicEnabled && schematicFile.exists()) {
                 new LobbyGenerator(lobby, schematicFile);
             } else {
+                if (schematicEnabled) System.out.println(Main.getConsolePrefix() + "AutoSetup: Die angegebene schematic Datei existiert nicht! Fallback zu Lobbygenerierung.");
                 new LobbyGenerator(lobby, ConfigSetting.AUTOSETUP_LOBBY_GENERATED_HEIGHT.getValueAsInt(), ConfigSetting.AUTOSETUP_LOBBY_GENERATED_SIZE.getValueAsInt());
             }
 

--- a/src/de/cuuky/varo/game/world/setup/AutoSetup.java
+++ b/src/de/cuuky/varo/game/world/setup/AutoSetup.java
@@ -144,9 +144,10 @@ public class AutoSetup {
                 return getGroundHeight(world, x, z) + heightSetting;
             case ABSOLUTE:
                 return heightSetting;
-            default:
             case MAX_HEIGHT:
                 return world.getMaxHeight() - heightSetting;
+            default:
+                throw new UnsupportedOperationException("This LobbySnap value is currently not implemented!");
         }
     }
 

--- a/src/de/cuuky/varo/game/world/setup/AutoSetup.java
+++ b/src/de/cuuky/varo/game/world/setup/AutoSetup.java
@@ -65,6 +65,7 @@ public class AutoSetup {
         setupLobby();
         setupBorder(middle);
         setupSpawns(middle);
+        setupAutoStart();
 
         System.out.println(Main.getConsolePrefix() + "AutoSetup: " + "Finished!");
         this.onFinish.run();
@@ -112,7 +113,9 @@ public class AutoSetup {
 
         middle.getWorld().setSpawnLocation(x, yPos, z);
         new SpawnGenerator(middle, ConfigSetting.AUTOSETUP_SPAWNS_RADIUS.getValueAsInt(), ConfigSetting.AUTOSETUP_SPAWNS_AMOUNT.getValueAsInt(), ConfigSetting.AUTOSETUP_SPAWNS_BLOCKID.getValueAsString(), ConfigSetting.AUTOSETUP_SPAWNS_SIDEBLOCKID.getValueAsString());
+    }
 
+    private void setupAutoStart(){
         if (ConfigSetting.AUTOSETUP_TIME_HOUR.isIntActivated() && ConfigSetting.AUTOSETUP_TIME_MINUTE.isIntActivated()) {
             System.out.println(Main.getConsolePrefix() + "AutoSetup: " + "Setting up AutoStart...");
             Calendar start = new GregorianCalendar();

--- a/src/de/cuuky/varo/game/world/setup/AutoSetup.java
+++ b/src/de/cuuky/varo/game/world/setup/AutoSetup.java
@@ -91,7 +91,7 @@ public class AutoSetup {
             File file = new File(ConfigSetting.AUTOSETUP_LOBBY_SCHEMATIC.getValueAsString());
             Location lobby = getLobbyLocation(world.getWorld(), x, z);
             if (!file.exists())
-                new LobbyGenerator(lobby, ConfigSetting.AUTOSETUP_LOBBY_HEIGHT.getValueAsInt(), ConfigSetting.AUTOSETUP_LOBBY_SIZE.getValueAsInt());
+                new LobbyGenerator(lobby, ConfigSetting.AUTOSETUP_LOBBY_GEN_HEIGHT.getValueAsInt(), ConfigSetting.AUTOSETUP_LOBBY_GEN_SIZE.getValueAsInt());
             else
                 new LobbyGenerator(lobby, file);
 

--- a/src/de/cuuky/varo/game/world/setup/AutoSetup.java
+++ b/src/de/cuuky/varo/game/world/setup/AutoSetup.java
@@ -131,11 +131,11 @@ public class AutoSetup {
         }
     }
 
-    private Location getLobbyLocation(World world, long x, long z) {
+    private Location getLobbyLocation(World world, int x, int z) {
         return new Location(world, x, getLobbyHeight(world, x, z), z);
     }
 
-    private int getLobbyHeight(World world, long x, long z) {
+    private int getLobbyHeight(World world, int x, int z) {
         int heightSetting = ConfigSetting.AUTOSETUP_LOBBY_SNAP_OFFSET.getValueAsInt();
         LobbySnap snapSetting = LobbySnap.valueOf(ConfigSetting.AUTOSETUP_LOBBY_SNAP.getValueAsString());
 
@@ -151,7 +151,7 @@ public class AutoSetup {
         }
     }
 
-    private int getGroundHeight(World world, long x, long z) {
+    private int getGroundHeight(World world, int x, int z) {
         int groundHeight = world.getMaxHeight();
 
         while (BlockUtils.isAir(new Location(world, x, groundHeight, z).getBlock()) && groundHeight > 0) {

--- a/src/de/cuuky/varo/game/world/setup/AutoSetup.java
+++ b/src/de/cuuky/varo/game/world/setup/AutoSetup.java
@@ -89,8 +89,6 @@ public class AutoSetup {
         if (ConfigSetting.AUTOSETUP_LOBBY_ENABLED.getValueAsBoolean()) {
             System.out.println(Main.getConsolePrefix() + "AutoSetup: " + "Loading the lobby...");
 
-            File file = new File(ConfigSetting.AUTOSETUP_LOBBY_SCHEMATIC.getValueAsString());
-
             Location lobby;
             try {
                 lobby = getLobbyLocation(world.getWorld(), x, z);
@@ -100,10 +98,12 @@ public class AutoSetup {
                 return;
             }
 
-            if (!file.exists())
-                new LobbyGenerator(lobby, ConfigSetting.AUTOSETUP_LOBBY_GEN_HEIGHT.getValueAsInt(), ConfigSetting.AUTOSETUP_LOBBY_GEN_SIZE.getValueAsInt());
-            else
-                new LobbyGenerator(lobby, file);
+            File schematicFile = new File(ConfigSetting.AUTOSETUP_LOBBY_SCHEMATIC_FILE.getValueAsString());
+            if (ConfigSetting.AUTOSETUP_LOBBY_SCHEMATIC_ENABLED.getValueAsBoolean() && schematicFile.exists()) {
+                new LobbyGenerator(lobby, schematicFile);
+            } else {
+                new LobbyGenerator(lobby, ConfigSetting.AUTOSETUP_LOBBY_GENERATED_HEIGHT.getValueAsInt(), ConfigSetting.AUTOSETUP_LOBBY_GENERATED_SIZE.getValueAsInt());
+            }
 
             Main.getVaroGame().setLobby(lobby);
         }

--- a/src/de/cuuky/varo/game/world/setup/AutoSetup.java
+++ b/src/de/cuuky/varo/game/world/setup/AutoSetup.java
@@ -136,16 +136,15 @@ public class AutoSetup {
     }
 
     private int getLobbyHeight(World world, int x, int z) {
-        int heightSetting = ConfigSetting.AUTOSETUP_LOBBY_SNAP_OFFSET.getValueAsInt();
-        LobbySnap snapSetting = LobbySnap.valueOf(ConfigSetting.AUTOSETUP_LOBBY_SNAP.getValueAsString());
+        LobbySnap snapSetting = LobbySnap.valueOf(ConfigSetting.AUTOSETUP_LOBBY_SNAP_TYPE.getValueAsString());
 
         switch (snapSetting) {
             case GROUND:
-                return getGroundHeight(world, x, z) + heightSetting;
+                return getGroundHeight(world, x, z) + ConfigSetting.AUTOSETUP_LOBBY_SNAP_GROUND_OFFSET.getValueAsInt();
             case ABSOLUTE:
-                return heightSetting;
+                return ConfigSetting.AUTOSETUP_LOBBY_SNAP_ABSOLUTE_YPOS.getValueAsInt();
             case MAX_HEIGHT:
-                return world.getMaxHeight() - heightSetting;
+                return world.getMaxHeight() - ConfigSetting.AUTOSETUP_LOBBY_SNAP_MAX_HEIGHT_OFFSET.getValueAsInt();
             default:
                 throw new UnsupportedOperationException("This LobbySnap value is currently not implemented!");
         }

--- a/src/de/cuuky/varo/game/world/setup/AutoSetup.java
+++ b/src/de/cuuky/varo/game/world/setup/AutoSetup.java
@@ -90,7 +90,16 @@ public class AutoSetup {
             System.out.println(Main.getConsolePrefix() + "AutoSetup: " + "Loading the lobby...");
 
             File file = new File(ConfigSetting.AUTOSETUP_LOBBY_SCHEMATIC.getValueAsString());
-            Location lobby = getLobbyLocation(world.getWorld(), x, z);
+
+            Location lobby;
+            try {
+                lobby = getLobbyLocation(world.getWorld(), x, z);
+            } catch (IllegalArgumentException ex) {
+                System.out.println(Main.getConsolePrefix() + "AutoSetup: The config value for lobby.snap.type is invalid!");
+                ex.printStackTrace();
+                return;
+            }
+
             if (!file.exists())
                 new LobbyGenerator(lobby, ConfigSetting.AUTOSETUP_LOBBY_GEN_HEIGHT.getValueAsInt(), ConfigSetting.AUTOSETUP_LOBBY_GEN_SIZE.getValueAsInt());
             else
@@ -115,7 +124,7 @@ public class AutoSetup {
         new SpawnGenerator(middle, ConfigSetting.AUTOSETUP_SPAWNS_RADIUS.getValueAsInt(), ConfigSetting.AUTOSETUP_SPAWNS_AMOUNT.getValueAsInt(), ConfigSetting.AUTOSETUP_SPAWNS_BLOCKID.getValueAsString(), ConfigSetting.AUTOSETUP_SPAWNS_SIDEBLOCKID.getValueAsString());
     }
 
-    private void setupAutoStart(){
+    private void setupAutoStart() {
         if (ConfigSetting.AUTOSETUP_TIME_HOUR.isIntActivated() && ConfigSetting.AUTOSETUP_TIME_MINUTE.isIntActivated()) {
             System.out.println(Main.getConsolePrefix() + "AutoSetup: " + "Setting up AutoStart...");
             Calendar start = new GregorianCalendar();


### PR DESCRIPTION
This pull request makes it possible to move the lobby spawned during autosetup on the Y-axis.
It is also possible to move the lobby to certain world-dependent points (ground, maximum height).
Among other things, this makes it possible to place lobbies directly on the ground, which is for example required for some Titan projects.