### PR TITLE
Check if preset location is valid

### DIFF
--- a/src/de/cuuky/varo/command/varo/PresetCommand.java
+++ b/src/de/cuuky/varo/command/varo/PresetCommand.java
@@ -41,10 +41,12 @@ public class PresetCommand extends VaroCommand {
 				return;
 			}
 
-			loader.loadSettings();
-			Main.getDataManager().reloadConfig();
-			Main.getDataManager().reloadPlayerClients();
-			sender.sendMessage(Main.getPrefix() + ConfigMessages.VARO_COMMANDS_PRESET_LOADED.getValue(vp).replace("%preset%", args[1]));
+			if (loader.loadSettings()) {
+				Main.getDataManager().reloadConfig();
+				Main.getDataManager().reloadPlayerClients();
+				sender.sendMessage(Main.getPrefix() + ConfigMessages.VARO_COMMANDS_PRESET_LOADED.getValue(vp).replace("%preset%", args[1]));
+			} else
+				sender.sendMessage(Main.getPrefix() + ConfigMessages.VARO_COMMANDS_PRESET_PATH_TRAVERSAL.getValue(vp).replace("%preset%", args[1]));
 		} else if (args[0].equalsIgnoreCase("save")) {
 			if (args.length != 2) {
 				sender.sendMessage(Main.getPrefix() + ConfigMessages.VARO_COMMANDS_PRESET_HELP_SAVE.getValue(vp));
@@ -52,8 +54,10 @@ public class PresetCommand extends VaroCommand {
 			}
 
 			PresetLoader loader = new PresetLoader(args[1]);
-			loader.copyCurrentSettingsTo();
-			sender.sendMessage(Main.getPrefix() + ConfigMessages.VARO_COMMANDS_PRESET_SAVED.getValue(vp).replace("%preset%", args[1]));
+			if (loader.copyCurrentSettingsTo())
+				sender.sendMessage(Main.getPrefix() + ConfigMessages.VARO_COMMANDS_PRESET_SAVED.getValue(vp).replace("%preset%", args[1]));
+			else
+				sender.sendMessage(Main.getPrefix() + ConfigMessages.VARO_COMMANDS_PRESET_PATH_TRAVERSAL.getValue(vp).replace("%preset%", args[1]));
 		} else if (args[0].equalsIgnoreCase("list")) {
 			File file = new File("plugins/Varo/presets");
 			sender.sendMessage(Main.getPrefix() + ConfigMessages.VARO_COMMANDS_PRESET_LIST.getValue(vp));

--- a/src/de/cuuky/varo/configuration/configurations/language/languages/ConfigMessages.java
+++ b/src/de/cuuky/varo/configuration/configurations/language/languages/ConfigMessages.java
@@ -262,6 +262,7 @@ public enum ConfigMessages implements DefaultLanguage {
 	VARO_COMMANDS_INTRO_GAME_ALREADY_STARTED("varoCommands.intro.gamealreadystarted", "&7Das Spiel wurde bereits gestartet!"),
 	VARO_COMMANDS_INTRO_STARTED("varoCommands.intro.started", "&7Und los geht's!"),
 	VARO_COMMANDS_PRESET_NOT_FOUND("varoCommands.preset.notfound", "Das Preset %colorcode%%preset% &7wurde nicht gefunden."),
+	VARO_COMMANDS_PRESET_PATH_TRAVERSAL("varoCommands.preset.pathtraversal", "Presets dürfen sich nur im &3presets&7-Order befinden."),
 	VARO_COMMANDS_PRESET_LOADED("varoCommands.preset.loaded", "Das Preset %colorcode%%preset% &7wurde &aerfolgreich &7geladen."),
 	VARO_COMMANDS_PRESET_SAVED("varoCommands.preset.saved", "Die aktuellen Einstellungen wurden &aerfolgreich &7als Preset %colorcode%%preset% &7gespeichert."),
 	VARO_COMMANDS_PRESET_LIST("varoCommands.preset.list", "&lListe aller Presets:"),

--- a/src/de/cuuky/varo/preset/PresetLoader.java
+++ b/src/de/cuuky/varo/preset/PresetLoader.java
@@ -20,7 +20,7 @@ public class PresetLoader {
 	}
 
 	private boolean copy(File from, File to) {
-		if (!Paths.get(file.getPath()).normalize().startsWith(PRESET_PATH))
+		if (!Paths.get(file.getPath()).normalize().startsWith(PRESET_PATH) || Paths.get(file.getPath()).normalize().equals(PRESET_PATH))
 			return false;
 
 		if (!to.exists())

--- a/src/de/cuuky/varo/preset/PresetLoader.java
+++ b/src/de/cuuky/varo/preset/PresetLoader.java
@@ -2,10 +2,14 @@ package de.cuuky.varo.preset;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import com.google.common.io.Files;
 
 public class PresetLoader {
+
+	private static final Path PRESET_PATH = Paths.get("plugins/Varo/presets/");
 
 	private final File file;
 	private final File configDir;
@@ -15,7 +19,10 @@ public class PresetLoader {
 		this.configDir = new File("plugins/Varo/config/");
 	}
 
-	private void copy(File from, File to) {
+	private boolean copy(File from, File to) {
+		if (!Paths.get(file.getPath()).normalize().startsWith(PRESET_PATH))
+			return false;
+
 		if (!to.exists())
 			to.mkdirs();
 
@@ -28,16 +35,18 @@ public class PresetLoader {
 				Files.copy(config, toFile);
 			} catch (IOException e) {
 				e.printStackTrace();
+				return false;
 			}
 		}
+		return true;
 	}
 
-	public void copyCurrentSettingsTo() {
-		this.copy(this.configDir, file);
+	public boolean copyCurrentSettingsTo() {
+		return this.copy(this.configDir, file);
 	}
 
-	public void loadSettings() {
-		this.copy(file, this.configDir);
+	public boolean loadSettings() {
+		return this.copy(file, this.configDir);
 	}
 
 	public File getFile() {


### PR DESCRIPTION
This fixes an issue regarding path traversal in the preset system.
As the issue has been discussed already, I'm not going to give a description on how to exploit it, but I was able to copy any file of the server to any location I want.

This PR simply checks if a preset would be located inside the preset directory. If not, the saving/loading fails.

![grafik](https://github.com/CuukyOfficial/VaroPlugin/assets/50475262/51683a98-0d87-4588-8db1-6600227b9fb7)
