### PR TITLE
fixed recursion bug causing crash

### DIFF
--- a/src/main/java/de/cuuky/varo/player/VaroPlayer.java
+++ b/src/main/java/de/cuuky/varo/player/VaroPlayer.java
@@ -138,9 +138,11 @@ public class VaroPlayer extends CustomLanguagePlayer implements CustomPlayer, Va
 	}
 
 	private int generateId() {
-		int id = JavaUtils.randomInt(1000, 9999999);
-		while (getPlayer(id) != null)
-			generateId();
+		int id;
+
+		do {
+			id = JavaUtils.randomInt(1000, 9999999);
+		} while (getPlayer(id) != null);
 
 		return id;
 	}

--- a/src/main/java/de/cuuky/varo/player/stats/stat/inventory/VaroSaveable.java
+++ b/src/main/java/de/cuuky/varo/player/stats/stat/inventory/VaroSaveable.java
@@ -75,9 +75,11 @@ public class VaroSaveable implements VaroSerializeable {
     }
 
     private int generateId() {
-        int id = JavaUtils.randomInt(1000, 9999999);
-        while (getSaveable(id) != null)
-            generateId();
+        int id;
+
+        do {
+            id = JavaUtils.randomInt(1000, 9999999);
+        } while (getSaveable(id) != null);
 
         return id;
     }

--- a/src/main/java/de/cuuky/varo/report/Report.java
+++ b/src/main/java/de/cuuky/varo/report/Report.java
@@ -47,9 +47,11 @@ public class Report implements VaroSerializeable {
 	}
 
 	private int generateId() {
-		int id = JavaUtils.randomInt(1000, 9999999);
-		while (getReport(id) != null)
-			generateId();
+		int id;
+
+		do {
+			id = JavaUtils.randomInt(1000, 9999999);
+		} while (getReport(id) != null);
 
 		return id;
 	}


### PR DESCRIPTION
There were some generateId methods which repeatedly called itself without a return value if JavaUtils#randomInt returned an ID that had already been used resulting in a crash

(This is just #109 but with the right branch)