### PR TITLE
Support nametag prefixes longer than 16 characters

### DIFF
--- a/src/main/java/de/cuuky/varo/configuration/configurations/config/ConfigSetting.java
+++ b/src/main/java/de/cuuky/varo/configuration/configurations/config/ConfigSetting.java
@@ -100,7 +100,7 @@ public enum ConfigSetting implements SectionEntry {
 	// DEATH
 	DEATH_SOUND_ENABLED(ConfigSettingSection.DEATH, "deathSound.enabled", false, "Ob ein Sound fuer alle abgespielt werden soll,\nsobald ein Spieler stirbt", true),
 	DEATH_SOUND(ConfigSettingSection.DEATH, "deathSound.sound", XSound.ENTITY_WITHER_AMBIENT.get(), "Sound der abgespielt werden soll", true),
-	DEBUG_OPTIONS(ConfigSettingSection.OTHER, "debugOptions", false, "Ob Debug Funktionen verfuegbar sein sollen.\nVorsicht: Mit Bedacht oder nur\nauf Anweisung nutzen!"),
+	DEBUG_OPTIONS(ConfigSettingSection.OTHER, "debugOptions", false, "Ob Debug Funktionen verfuegbar sein sollen.\nVorsicht: Mit Bedacht oder nur\nauf Anweisung nutzen."),
 	BLOCK_ADVANCEMENTS(ConfigSettingSection.OTHER, "blockAdvancements", true, "Ob Advancements deaktiviert werden sollen [1.12+]"),
 
 	// DISCONNECT
@@ -122,6 +122,7 @@ public enum ConfigSetting implements SectionEntry {
 	DISCORDBOT_EVENT_WIN(ConfigSettingSection.DISCORD, "eventChannel.win", -1L, "ID's des Channels, wo die Winnachricht gepostet wird.\n-1= EventChannelID wird genutzt"),
 	DISCORDBOT_EVENT_YOUTUBE(ConfigSettingSection.DISCORD, "eventChannel.youtube", -1L, "ID's des Channels, wo die YT-Videos gepostet werden.\n-1= EventChannelID wird genutzt"),
 	DISCORDBOT_EVENT_CHANNELID(ConfigSettingSection.DISCORD, "eventChannelID", -1L, "Gib hier die ChannelID des Channels an,\nin welchen der Bot Events posten soll.\nRechtsklick auf den Channel -> 'Copy ChannelID'\nWenn Option nicht vorhanden, schalte\n'developer options' in den Einstellungen von Discord ein."),
+
 	DISCORDBOT_GAMESTATE(ConfigSettingSection.DISCORD, "gameState", "Varo | Plugin by Cuuky - Contributors: Korne127, UeberallGebannt", "Stelle hier ein, was der Bot\nim Spiel als Name haben soll."),
 	DISCORDBOT_INVITELINK(ConfigSettingSection.DISCORD, "inviteLink", "ENTER LINK HERE", "Stelle hier deinen Link zum Discord ein"),
 
@@ -179,6 +180,7 @@ public enum ConfigSetting implements SectionEntry {
 	NAMETAGS_VISIBLE_DEFAULT(ConfigSettingSection.MAIN, "nametags.visible.default", true, "Ob NameTags sichtbar sein sollen"),
 	NAMETAGS_VISIBLE_TEAM(ConfigSettingSection.MAIN, "nametags.visible.team", true, "Ob NameTags für das eigene Team sichtbar sein sollen\nwenn nametags.visible.default deaktiviert ist"),
 	NAMETAGS_VISIBLE_SPECTATOR(ConfigSettingSection.MAIN, "nametags.visible.spectator", true, "Ob NameTags für Spectator sichtbar sein sollen\nwenn nametags.visible.default deaktiviert ist"),
+	NAMETAGS_USE_ARMOR_STANDS(ConfigSettingSection.MAIN, "nametags.useArmorStands", false, "Ob unsichtbare Rüstungsständer für Nametags verwendet werden sollen"),
 
 	NO_ACTIVITY_DAYS(ConfigSettingSection.ACTIVITY, "noActivityDays", -1, "Nach wie vielen Tagen ohne Aktiviaet auf dem\nServer der Spieler gemeldet werden soll.\nOff = -1"),
 
@@ -305,7 +307,7 @@ public enum ConfigSetting implements SectionEntry {
 	TABLIST_USE_HEADER(ConfigSettingSection.TABLIST, "useHeader", true, "Ob die Tablist einen Header haben soll.\nErfordert config reload und ggf. rejoin."),
 	TABLIST_USE_FOOTER(ConfigSettingSection.TABLIST, "useFooter", true, "Ob die Tablist einen Footer haben soll.\nErfordert config reload und ggf. rejoin."), // enable: config reload
 	TABLIST_CHANGE_NAMES(ConfigSettingSection.TABLIST, "changeNames", true, "Ob die Namen in der Tablist modfiziert werden sollen."),
-	
+
 	// COMMANDS
 	COMMAND_ANTIXRAY_ENABLED(ConfigSettingSection.COMMANDS, "antixray.enabled", true, "Ob /antixray aktiviert sein soll"),
 	COMMAND_BORDER_ENABLED(ConfigSettingSection.COMMANDS, "border.enabled", true, "Ob /border aktiviert sein soll"),

--- a/src/main/java/de/cuuky/varo/listener/PlayerMoveListener.java
+++ b/src/main/java/de/cuuky/varo/listener/PlayerMoveListener.java
@@ -2,6 +2,8 @@ package de.cuuky.varo.listener;
 
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -49,6 +51,11 @@ public class PlayerMoveListener implements Listener {
 				vp.sendMessage(ConfigMessages.JOIN_NO_MOVE_IN_PROTECTION);
 				return;
 			}
+		}
+
+		// Move the armor stand nametag with the player
+		if (ConfigSetting.NAMETAGS_USE_ARMOR_STANDS.getValueAsBoolean()) {
+			vp.updateArmorStandNametagPos(to);
 		}
 	}
 }

--- a/src/main/java/de/cuuky/varo/player/VaroPlayer.java
+++ b/src/main/java/de/cuuky/varo/player/VaroPlayer.java
@@ -7,7 +7,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Sound;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffectType;
@@ -112,6 +114,7 @@ public class VaroPlayer extends CustomLanguagePlayer implements CustomPlayer, Va
 	private ScoreboardInstance scoreboardInstance;
 	private boolean alreadyHadMassProtectionTime, inMassProtectionTime, massRecordingKick;
 	private ChatMessage lastMessage;
+	private ArmorStand armorStandNametag;
 
 	public VaroPlayer() {
 		varoplayer.add(this);
@@ -357,6 +360,15 @@ public class VaroPlayer extends CustomLanguagePlayer implements CustomPlayer, Va
 						for (VaroTeam team : VaroTeam.getOnlineTeams())
 							team.getNameTagGroup().update(this.player, team == this.team && !potion, name, prefix, suffix);
 				}
+				if (ConfigSetting.NAMETAGS_USE_ARMOR_STANDS.getValueAsBoolean()) {
+					if (this.armorStandNametag == null) {
+						this.createArmorStandNametag();
+					} else {
+						this.updateArmorStandNametag();
+					}
+				} else {
+					this.removeArmorStandNametag();
+				}
 			}
 		}
 	}
@@ -413,6 +425,36 @@ public class VaroPlayer extends CustomLanguagePlayer implements CustomPlayer, Va
 		if (suffix.length() > 16)
 			suffix = suffix.substring(0, 16);
 		return suffix;
+	}
+
+	private void createArmorStandNametag() {
+		Location location = this.player.getLocation().clone().add(0, 2.5, 0);
+		this.armorStandNametag = this.player.getWorld().spawn(location, ArmorStand.class);
+		this.armorStandNametag.setVisible(false);
+		this.armorStandNametag.setCustomNameVisible(true);
+		this.updateArmorStandNametag();
+	}
+
+	private void updateArmorStandNametag() {
+		this.armorStandNametag.setCustomName(this.getNametagPrefix() + this.player.getName() + this.getNametagSuffix());
+	}
+
+	private void removeArmorStandNametag() {
+		if (this.armorStandNametag != null) {
+			this.armorStandNametag.remove();
+			this.armorStandNametag = null;
+		}
+	}
+
+	public void updateArmorStandNametagPos(Location to) {
+		Entity armorStand = this.armorStandNametag;
+		if (armorStand != null && armorStand instanceof ArmorStand) {
+			Location armorStandLocation = armorStand.getLocation();
+			armorStandLocation.setX(to.getX());
+			armorStandLocation.setY(to.getY() + 2); // Adjust the Y offset as needed
+			armorStandLocation.setZ(to.getZ());
+			armorStand.teleport(armorStandLocation);
+		}
 	}
 
 	public void saveTeleport(Location location) {


### PR DESCRIPTION
Fixes #108

Add a new setting to enable or disable the use of invisible armor stands for nametags.

* Add `NAMETAGS_USE_ARMOR_STANDS` setting in `ConfigSetting` to enable or disable the use of invisible armor stands for nametags.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CuukyOfficial/VaroPlugin/issues/108?shareId=XXXX-XXXX-XXXX-XXXX).